### PR TITLE
Fix X509_REQ_INFO enc_len with Linux 64 bits

### DIFF
--- a/ManagedOpenSsl/X509/X509Request.cs
+++ b/ManagedOpenSsl/X509/X509Request.cs
@@ -92,7 +92,14 @@ namespace OpenSSL.X509
 			#region ASN1_ENCODING enc;
 
 			public IntPtr enc_enc;
+			// enc_len is declared natively as long
+			// http://stackoverflow.com/questions/384502/what-is-the-bit-size-of-long-on-64-bit-windows
+			// this is an attempt to map it in a portable way:
+#if _WIN64
+			public int enc_len;
+#else
 			public IntPtr enc_len;
+#endif
 			public int enc_modified;
 
 			#endregion

--- a/ManagedOpenSsl/X509/X509Request.cs
+++ b/ManagedOpenSsl/X509/X509Request.cs
@@ -92,7 +92,7 @@ namespace OpenSSL.X509
 			#region ASN1_ENCODING enc;
 
 			public IntPtr enc_enc;
-			public int enc_len;
+			public IntPtr enc_len;
 			public int enc_modified;
 
 			#endregion


### PR DESCRIPTION
Hello,

In OpenSSL sources, ASN1_ENCODING len is defined as a long, which is 32 bits on Windows 64 bits; but 64 bits on other systems (like GNU/Linux). Changing len type from int to IntPtr allows to handle both cases, and prevent data truncation.